### PR TITLE
Improve handling of WHMCS configurable options for AutoVM product server module

### DIFF
--- a/includes/hooks/autovm/controller.php
+++ b/includes/hooks/autovm/controller.php
@@ -221,7 +221,7 @@ class AVMController
         // Find allowed templates
         $params = ['packageId' => $service->packageid];
 
-        $templates = Capsule::select("SELECT a.optionname as name FROM tblproductconfigoptionssub a INNER JOIN tblproductconfigoptions b ON b.id = a.configid INNER JOIN tblproductconfiglinks c ON c.gid = b.gid WHERE b.optionname LIKE '%template%' AND c.pid = :packageId", $params);
+        $templates = Capsule::select("SELECT a.optionname as name FROM tblproductconfigoptionssub a INNER JOIN tblproductconfigoptions b ON b.id = a.configid INNER JOIN tblproductconfiglinks c ON c.gid = b.gid WHERE a.hidden=0 AND b.optionname LIKE '%template%' AND c.pid = :packageId", $params);
 
         // List allowed templates
         $allowdTemplates = [];

--- a/modules/servers/product/views/view/assets/js/main.js
+++ b/modules/servers/product/views/view/assets/js/main.js
@@ -333,6 +333,28 @@ const app = Vue.createApp({
 
         },
 
+        findTemplateDisplayName() {
+
+            let cats = this.categories
+
+            let id = this.templateId
+
+            for (let i = 0; i < cats.length; i++) {
+
+                let temp = cats[i].templates
+
+                for (let j = 0; j < temp.length; j++) {
+                    if (temp[j].id == id) {
+                        this.tempDisplayNameSetup = temp[j].name
+                        return temp[j].name;
+                    }
+                }
+            }
+
+            return 'er';
+
+        },
+
         findTemplateIcon() {
 
             let cats = this.categories
@@ -555,6 +577,12 @@ const app = Vue.createApp({
             let tempName = null
             tempName = this.getMachineProperty('template.name')
             return tempName
+        },
+
+        tempDisplayName() {
+            let tempDisplayName = null
+            tempDisplayName = this.getMachineProperty('template.display_name')
+            return tempDisplayName
         },
 
         tempIcon() {
@@ -2044,8 +2072,10 @@ const app = Vue.createApp({
             }
 
             let templateName = templates.find(findname).name
+            let templateDisplayName = templates.find(findname).display_name
             let templateIcon = templates.find(findname).icon.address
             this.tempNameSetup = templateName
+            this.tempDisplayNameSetup = templateDisplayName
             this.tempIconSetup = templateIcon
 
         },

--- a/modules/servers/product/views/view/changeos.php
+++ b/modules/servers/product/views/view/changeos.php
@@ -22,7 +22,7 @@
                     <div class="py-1 pe-3 flex-grow-1" style="min-width:190px;">
                         <select v-model="templateId" class="form-select">
                             <option v-for="template in category.templates" :value="template.id">
-                                {{ template.name }}
+                                {{ template.display_name || template.name }}
                             </option>
                         </select>
                     </div>

--- a/modules/servers/product/views/view/hoststatus.php
+++ b/modules/servers/product/views/view/hoststatus.php
@@ -1,7 +1,7 @@
 <!-- TITLE row -->
 <div class="d-flex flex-row justify-content-between align-items-center m-0 p-0 pb-5 ps-2">
     <!-- Hostname -->
-    <div class="text-start p-0 m-0" style="max-width: 225px;">
+    <div class="text-start p-0 m-0" style="max-width: 420px;">
         <div class="d-flex flex-row m-0 p-0">
 
             <span class="fs-5 fw-medium m-0 p-0">{{ lang('hostname') }}</span>

--- a/modules/servers/product/views/view/machinedetals.php
+++ b/modules/servers/product/views/view/machinedetals.php
@@ -133,7 +133,10 @@
                     <img v-if="tempIcon != null" :src="tempIcon" alt="templateicon" width="23">
                     <img v-if="softIcon != null" :src="softIcon" alt="templateicon" width="23">
                 </div>
-                <span v-if="tempName" class="m-0 p-0 fs-4 ms-2">
+                <span v-if="tempDisplayName" class="m-0 p-0 fs-4 ms-2">
+                    {{ tempDisplayName }}
+                </span>
+                <span v-if="tempName && !tempDisplayName" class="m-0 p-0 fs-4 ms-2">
                     {{ tempName }}
                 </span>
                 <span v-if="softName" class="m-0 p-0 fs-4 ms-2">


### PR DESCRIPTION
Bugfixes / Improvements to WHMCS product module

- Template Configurable Options set to hidden will not be displayed in Change OS
- UI support for WHMCS's standard value|display name format in configurable options
- Template Configurable Options using the value|display name format correctly filter allowed templates
- Template Configurable Options using the value|display name format, correctly show display name in Change OS selects and the current template in machine details
- Increased max-width of hostname to prevent line breaks unless names are long